### PR TITLE
Add the option to set client.id to storm-kafka and storm-kafka-client

### DIFF
--- a/docs/storm-kafka-client.md
+++ b/docs/storm-kafka-client.md
@@ -165,6 +165,8 @@ streams based on the topic, storm provides `ByTopicRecordTranslator`.  See below
 
 `setGroupId` lets you set the id of the kafka consumer group property "group.id'
 
+`setClientId` lets you set the id of the kafka consumer client property "client.id'
+
 `setSSLKeystore` and `setSSLTruststore` allow you to configure SSL authentication.
 
 ### Usage Examples

--- a/docs/storm-kafka.md
+++ b/docs/storm-kafka.md
@@ -57,11 +57,14 @@ The optional ClientId is used as a part of the ZooKeeper path where the spout's 
 
 There are 2 extensions of KafkaConfig currently in use.
 
-Spoutconfig is an extension of KafkaConfig that supports additional fields with ZooKeeper connection info and for controlling
-behavior specific to KafkaSpout. The Zkroot will be used as root to store your consumer's offset. The id should uniquely
-identify your spout.
+SpoutConfig is an extension of KafkaConfig that supports additional fields with ZooKeeper connection info and for controlling
+behavior specific to KafkaSpout.
+The clientId will be used to identify requests which are made using the Kafka Protocol.
+The zkRoot will be used as root to store your consumer's offset.
+The id should uniquely identify your spout.
 
 ```java
+public SpoutConfig(BrokerHosts hosts, String topic, String clientId, String zkRoot, String id);
 public SpoutConfig(BrokerHosts hosts, String topic, String zkRoot, String id);
 ```
 

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java
@@ -251,6 +251,13 @@ public class KafkaSpoutConfig<K, V> implements Serializable {
         }
         
         /**
+         * Set the client.id for the consumers
+         */
+        public Builder<K,V> setClientId(String id) {
+            return setProp("client.id", id);
+        }
+        
+        /**
          * reset the bootstrap servers for the Consumer
          */
         public Builder<K,V> setBootstrapServers(String servers) {
@@ -505,6 +512,10 @@ public class KafkaSpoutConfig<K, V> implements Serializable {
 
     public String getConsumerGroupId() {
         return (String) kafkaProps.get(ConsumerConfig.GROUP_ID_CONFIG);
+    }
+
+    public String getConsumerClientId() {
+        return (String) kafkaProps.get(ConsumerConfig.CLIENT_ID_CONFIG);
     }
 
     public FirstPollOffsetStrategy getFirstPollOffsetStrategy() {

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/SpoutConfig.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/SpoutConfig.java
@@ -47,4 +47,10 @@ public class SpoutConfig extends KafkaConfig implements Serializable {
         this.zkRoot = zkRoot;
         this.id = id;
     }
+
+    public SpoutConfig(BrokerHosts hosts, String topic, String clientId, String zkRoot, String id) {
+        super(hosts, topic, clientId);
+        this.zkRoot = zkRoot;
+        this.id = id;
+    }
 }


### PR DESCRIPTION
Add the ability to set the Kafka client.id property to storm-kafka and storm-kafka-client.

storm-kafka example:
```
	SpoutConfig spoutConfig = new SpoutConfig(
		brokers,
		topicConfs.topic,
+		"client_id-" + confs.consumerGroupId + "-" + topicConfs.topic,
		"/consumers",
		confs.consumerGroupId + "-" + topicConfs.topic
	);
```

storm-kafka-client example:
```
	KafkaSpoutConfig<String,String> kafkaSpoutConfig = KafkaSpoutConfig.builder(KAFKA_LOCAL_BROKER, TOPIC)
		.setGroupId(confs.consumerGroupId + "-" + topicConfs.topic)
+		.setClientId("client_id-" + confs.consumerGroupId + "-" + topicConfs.topic)
		.build();
```